### PR TITLE
Fix paths under '$HOME' not listed on Windows

### DIFF
--- a/autoload/ddu/source/file_old.vim
+++ b/autoload/ddu/source/file_old.vim
@@ -1,5 +1,5 @@
 function! ddu#source#file_old#_get_oldfiles() abort
   return filter(map(copy(v:oldfiles),
-        \ { _, val -> substitute(val, '^\~', $HOME, '') }),
+        \ { _, val -> substitute(val, '^\~', '\=$HOME', '') }),
         \ { _, val -> filereadable(val) })
 endfunction


### PR DESCRIPTION
If `$HOME` contains backslashes, `substitute()` misunderstands some special meanings on it, resulting in paths under `$HOME` not being listed on Windows.
Use `'\=$HOME'` instead, which disables those special meanings (`:h s/\=`).